### PR TITLE
Java Improvements ~10% runtime improvement in single-threaded mode

### DIFF
--- a/src/ch/agsl/dynarapid/entry/GenerateRouted.java
+++ b/src/ch/agsl/dynarapid/entry/GenerateRouted.java
@@ -7,59 +7,22 @@
 */
 
 package ch.agsl.dynarapid.entry;
-import ch.agsl.dynarapid.databasegenerator.*;
-import ch.agsl.dynarapid.debug.*;
-import ch.agsl.dynarapid.entry.*;
-import ch.agsl.dynarapid.error.*; 
-import ch.agsl.dynarapid.graphgenerator.*;
-import ch.agsl.dynarapid.graphplacer.*;
-import ch.agsl.dynarapid.interrouting.*;
-import ch.agsl.dynarapid.map.*;
-import ch.agsl.dynarapid.modules.*;
-import ch.agsl.dynarapid.parser.*;
-import ch.agsl.dynarapid.pblockgenerator.*;
-import ch.agsl.dynarapid.placer.*;
-     
-import ch.agsl.dynarapid.strings.*;
-import ch.agsl.dynarapid.synthesizer.*;
-import ch.agsl.dynarapid.tclgenerator.*;
-import ch.agsl.dynarapid.vivado.*;
 
+import ch.agsl.dynarapid.GenerateDesign;
+import ch.agsl.dynarapid.parser.LocationParser;
+import ch.agsl.dynarapid.strings.StringUtils;
 
-//This routes the designs simply either filly or partially based on teh arguments passed
-
-import com.xilinx.rapidwright.design.DesignTools;
-import com.xilinx.rapidwright.design.Cell;
 import com.xilinx.rapidwright.design.Design;
-import com.xilinx.rapidwright.design.Module;
-import com.xilinx.rapidwright.design.ModuleInst;
-import com.xilinx.rapidwright.design.SiteInst;
-import com.xilinx.rapidwright.design.SitePinInst;
-import com.xilinx.rapidwright.design.Net;
-import com.xilinx.rapidwright.device.Device;
-import com.xilinx.rapidwright.device.BEL;
-import com.xilinx.rapidwright.device.BELPin;
-import com.xilinx.rapidwright.device.Site;
-import com.xilinx.rapidwright.device.Tile;
-import com.xilinx.rapidwright.device.SiteTypeEnum;
-import com.xilinx.rapidwright.device.TileTypeEnum;
-import com.xilinx.rapidwright.device.helper.TileColumnPattern;
-import com.xilinx.rapidwright.edif.EDIFCell;
-import com.xilinx.rapidwright.edif.EDIFDirection;
-import com.xilinx.rapidwright.edif.EDIFNet;
-import com.xilinx.rapidwright.edif.EDIFNetlist;
+import com.xilinx.rapidwright.design.DesignTools;
 import com.xilinx.rapidwright.edif.EDIFTools;
-import com.xilinx.rapidwright.tests.CodePerfTracker;
-import com.xilinx.rapidwright.examples.SLRCrosserGenerator;
-import com.xilinx.rapidwright.router.Router;
-import com.xilinx.rapidwright.placer.handplacer.HandPlacer;
-import com.xilinx.rapidwright.rwroute.RWRoute;
 import com.xilinx.rapidwright.rwroute.PartialRouter;
+import com.xilinx.rapidwright.rwroute.RWRoute;
 
-import java.io.*;
-import java.util.*;
-import java.lang.*;
+import java.nio.file.Path;
 
+/** 
+ * This routes the designs simply either fully or partially based on the arguments passed
+ */
 public class GenerateRouted {
 
     //This routes the design partially with the unconnected inputs being grounded
@@ -87,7 +50,7 @@ public class GenerateRouted {
     // }
     
     //This helps route the design partially and puts the design in the final location
-    public static boolean routeDesignPartially(Design design, String finalLocation)
+    public static boolean routeDesignPartially(Design design, Path finalLocation)
     {
         StringUtils.printIntro("Started partial routing using RWRouter");
         design.flattenDesign();
@@ -122,7 +85,7 @@ public class GenerateRouted {
 
     //Thsi routes the design and puts it in teh given final location
     //NOTE: The final location must have the entire loccation including the name
-    public static boolean routeDesignFully(Design design, String finalLocation)
+    public static boolean routeDesignFully(Design design, Path finalLocation)
     {
         StringUtils.printIntro("Started full routing using RWRouter");
         design.getNetlist().resetParentNetMap();
@@ -143,7 +106,7 @@ public class GenerateRouted {
         }
 
         String dcpLoc = args[StringUtils.findInArray("-f", args) + 1];
-        String finalLoc = LocationParser.designs + StringUtils.getGraphName(dcpLoc) + "_routed.dcp";
+        Path finalLoc = GenerateDesign.getDefaultOutputDCPPath(StringUtils.getGraphName(dcpLoc));
         Design design = Design.readCheckpoint(dcpLoc);
         boolean status = false;
 

--- a/src/ch/agsl/dynarapid/graphplacer/GraphPlacer.java
+++ b/src/ch/agsl/dynarapid/graphplacer/GraphPlacer.java
@@ -7,59 +7,29 @@
 */
 package ch.agsl.dynarapid.graphplacer;
 
-import  ch.agsl.dynarapid.*;
-import ch.agsl.dynarapid.databasegenerator.*;
-import ch.agsl.dynarapid.debug.*;
-import ch.agsl.dynarapid.entry.*;
-import ch.agsl.dynarapid.error.*;
-import ch.agsl.dynarapid.graphgenerator.*;
-import ch.agsl.dynarapid.graphplacer.*;
-import ch.agsl.dynarapid.interrouting.*;
-import ch.agsl.dynarapid.map.*;
-import ch.agsl.dynarapid.modules.*;
-import ch.agsl.dynarapid.parser.*;
-import ch.agsl.dynarapid.pblockgenerator.*;
-import ch.agsl.dynarapid.placer.*;
-     
-import ch.agsl.dynarapid.strings.*;
-import ch.agsl.dynarapid.synthesizer.*;
-import ch.agsl.dynarapid.tclgenerator.*;
-import ch.agsl.dynarapid.vivado.*;
-//This places the moduified graph of nodes that it recieves from the placement algorithm
-//It is supposed to run checks but can be overridden for quick dcp generation
+import ch.agsl.dynarapid.GenerateDesign;
+import ch.agsl.dynarapid.debug.TimeProfiler;
+import ch.agsl.dynarapid.entry.GenerateRouted;
+import ch.agsl.dynarapid.modules.Node;
+import ch.agsl.dynarapid.modules.Shape;
+import ch.agsl.dynarapid.parser.LocationParser;
+import ch.agsl.dynarapid.strings.StringUtils;
 
-import com.xilinx.rapidwright.design.DesignTools;
-import com.xilinx.rapidwright.design.Cell;
 import com.xilinx.rapidwright.design.Design;
 import com.xilinx.rapidwright.design.Module;
-import com.xilinx.rapidwright.design.ModuleInst;
-import com.xilinx.rapidwright.design.SiteInst;
-import com.xilinx.rapidwright.design.SitePinInst;
-import com.xilinx.rapidwright.design.Net;
-import com.xilinx.rapidwright.device.Device;
-import com.xilinx.rapidwright.device.BEL;
-import com.xilinx.rapidwright.device.BELPin;
-import com.xilinx.rapidwright.device.Site;
-import com.xilinx.rapidwright.device.Tile;
-import com.xilinx.rapidwright.device.SiteTypeEnum;
-import com.xilinx.rapidwright.device.TileTypeEnum;
-import com.xilinx.rapidwright.device.helper.TileColumnPattern;
 import com.xilinx.rapidwright.edif.EDIFCell;
 import com.xilinx.rapidwright.edif.EDIFDirection;
 import com.xilinx.rapidwright.edif.EDIFNet;
 import com.xilinx.rapidwright.edif.EDIFPort;
-import com.xilinx.rapidwright.edif.EDIFNetlist;
-import com.xilinx.rapidwright.tests.CodePerfTracker;
 import com.xilinx.rapidwright.examples.SLRCrosserGenerator;
-import com.xilinx.rapidwright.router.Router;
-import com.xilinx.rapidwright.placer.handplacer.HandPlacer;
-import com.xilinx.rapidwright.rwroute.RWRoute;
-import com.xilinx.rapidwright.rwroute.PartialRouter;
 
-import java.io.*;
-import java.util.*;
-import java.util.concurrent.*;
-import java.lang.*;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 public class GraphPlacer {
     
@@ -230,10 +200,11 @@ public class GraphPlacer {
             return false;
         
         //Starting the routing of the design
+        Path dcpFile = GenerateDesign.getDefaultOutputDCPPath(graphName);
         if(!complete)
-            return GenerateRouted.routeDesignPartially(design, LocationParser.designs + graphName + "/" + graphName + "_routed.dcp");
+            return GenerateRouted.routeDesignPartially(design, dcpFile);
 
         else 
-            return GenerateRouted.routeDesignFully(design, LocationParser.designs + graphName + "/" + graphName + "_routed.dcp");
+            return GenerateRouted.routeDesignFully(design, dcpFile);
     }
 }


### PR DESCRIPTION
This does two things:
1) Replaces the `Scanner` instance with `BufferedReader`
2) Uses `String.split()` instead of the customized `StringUtils` method

This leads to a anecdotal speedup of ~10% when in single threaded mode, and almost brings single threaded mode on par with multi-threaded mode.